### PR TITLE
Add gofit to osx_64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -464,6 +464,7 @@ go-ghq
 go-licenses
 go-shfmt
 go-yq
+gofit
 google-cloud-cpp
 google-cloud-sdk
 google-pasta


### PR DESCRIPTION
Add `gofit` to the `osx-arm64` migration list.